### PR TITLE
fix: don't read metadata files in component store

### DIFF
--- a/src/main/java/com/aws/greengrass/deployment/templating/TemplateEngine.java
+++ b/src/main/java/com/aws/greengrass/deployment/templating/TemplateEngine.java
@@ -40,6 +40,7 @@ import static com.aws.greengrass.deployment.DeploymentService.parseFile;
  */
 public class TemplateEngine {
     public static final String PARSER_JAR = "transformer.jar";
+    public static final String METADATA_JSON_EXT = ".metadata.json";
 
     private final ComponentStore componentStore;
     private final NucleusPaths nucleusPaths;
@@ -120,7 +121,8 @@ public class TemplateEngine {
     void scanComponentsIntoEngine(Path recipeDirectoryPath) throws IOException {
         try (Stream<Path> files = Files.walk(recipeDirectoryPath)) {
             for (Path r : files.collect(Collectors.toList())) {
-                if (!r.toFile().isDirectory()) {
+                System.out.println(r.getFileName().toString());
+                if (!r.toFile().isDirectory() && !r.getFileName().toString().endsWith(METADATA_JSON_EXT)) {
                     scanComponentIntoEngine(r);
                 }
             }
@@ -134,6 +136,7 @@ public class TemplateEngine {
                 recipe.getComponentVersion());
         mapOfComponentIdentifierToRecipe.put(identifier, recipe);
         if (recipe.getComponentType().equals(ComponentType.TEMPLATE)) {
+            // will implicitly keep the latest version only
             mapOfTemplateNameToTemplateIdentifier.put(recipe.getComponentName(), identifier);
         }
     }

--- a/src/main/java/com/aws/greengrass/deployment/templating/TemplateEngine.java
+++ b/src/main/java/com/aws/greengrass/deployment/templating/TemplateEngine.java
@@ -121,9 +121,11 @@ public class TemplateEngine {
     void scanComponentsIntoEngine(Path recipeDirectoryPath) throws IOException {
         try (Stream<Path> files = Files.walk(recipeDirectoryPath)) {
             for (Path r : files.collect(Collectors.toList())) {
-                System.out.println(r.getFileName().toString());
-                if (!r.toFile().isDirectory() && !r.getFileName().toString().endsWith(METADATA_JSON_EXT)) {
-                    scanComponentIntoEngine(r);
+                if (!r.toFile().isDirectory()) {
+                    Path file = r.getFileName();
+                    if (file != null && !file.toString().endsWith(METADATA_JSON_EXT)) {
+                        scanComponentIntoEngine(r);
+                    }
                 }
             }
         }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Small patch to fix a bug where templating engine reads `.metadata.json` files in addition to recipes.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
