### PR TITLE
feat: persist templates until all dependents are removed

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/templating/TemplateEngineIntegTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/deployment/templating/TemplateEngineIntegTest.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.integrationtests.deployment.templating;
 
 import com.amazon.aws.iot.greengrass.component.common.ComponentRecipe;
+import com.amazon.aws.iot.greengrass.component.common.Platform;
 import com.aws.greengrass.componentmanager.exceptions.PackageDownloadException;
 import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.deployment.DeploymentDocumentDownloader;
@@ -280,8 +281,14 @@ public class TemplateEngineIntegTest extends BaseITCase {
                                     recipe.getManifests().get(0).getLifecycle().get("run"));
                             break;
                         }
+                        case "ATemplate":
+                        case "LoggerTemplate": {
+                            assertEquals(0, recipe.getManifests().get(0).getLifecycle().size());
+                            assertEquals(Platform.OS.ALL, recipe.getManifests().get(0).getPlatform().getOs());
+                            break;
+                        }
                         default: {
-                            fail("Found recipe file other than loggers A,B,C");
+                            fail("Found recipe file other than loggers A,B,C, LoggerTemplate, and ATemplate");
                             break;
                         }
                     }
@@ -308,8 +315,15 @@ public class TemplateEngineIntegTest extends BaseITCase {
                                     recipe.getManifests().get(0).getLifecycle().get("run"));
                             break;
                         }
+                        case "ADependentTemplate":
+                        case "BDependentTemplate": {
+                            assertEquals(0, recipe.getManifests().get(0).getLifecycle().size());
+                            assertEquals(Platform.OS.ALL, recipe.getManifests().get(0).getPlatform().getOs());
+                            break;
+                        }
                         default: {
-                            fail("Found recipe file other than ADependent, BDependent");
+                            fail("Found recipe file other than ADependent, BDependent, ADependentTemplate, "
+                                    + "BDependentTemplate");
                             break;
                         }
                     }

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/templating/dependent/recipes/ADependentTemplate-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/templating/dependent/recipes/ADependentTemplate-1.0.0.yaml
@@ -4,3 +4,10 @@ componentName: ADependentTemplate
 componentVersion: '1.0.0'
 componentType: aws.greengrass.template
 templateParameterSchema: {}
+manifests:
+  - platform:
+      os: '*'
+    lifecycle: {}
+    artifacts:
+      - uri: "greengrass:transformer.jar"
+        unarchive: NONE

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/templating/dependent/recipes/BDependentTemplate-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/templating/dependent/recipes/BDependentTemplate-1.0.0.yaml
@@ -4,3 +4,10 @@ componentName: BDependentTemplate
 componentVersion: '1.0.0'
 componentType: aws.greengrass.template
 templateParameterSchema: {}
+manifests:
+  - platform:
+      os: '*'
+    lifecycle: {}
+    artifacts:
+      - uri: "greengrass:transformer.jar"
+        unarchive: NONE

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/templating/nondependent/recipes/ATemplate-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/templating/nondependent/recipes/ATemplate-1.0.0.yaml
@@ -11,3 +11,10 @@ templateParameterSchema:
   param2:
     type: string
     required: true
+manifests:
+  - platform:
+      os: '*'
+    lifecycle: {}
+    artifacts:
+      - uri: "greengrass:transformer.jar"
+        unarchive: NONE

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/templating/nondependent/recipes/LoggerTemplate-1.0.0.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/deployment/templating/nondependent/recipes/LoggerTemplate-1.0.0.yaml
@@ -15,3 +15,10 @@ templateParameterSchema:
     type: string
     required: false
     defaultValue: Ping pong its a default message
+manifests:
+  - platform:
+      os: '*'
+    lifecycle: {}
+    artifacts:
+      - uri: "greengrass:transformer.jar"
+        unarchive: NONE


### PR DESCRIPTION
**Issue #, if available:**
[P49950306] Persist templates in component store until all dependent components are removed

**Description of changes:**
Ensure expanded recipes maintain a dependence on the template to keep the artifacts in component store.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
